### PR TITLE
Added support for a nested activator in PerControllerConfigActivator

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,5 @@
 ### 1.1.0
-* WIP
+* Added support for a nested activator in `PerControllerConfigActivator`
 
 ### 1.0 - 23 March 2015
 * First release.

--- a/src/Climax.Web.Http/Services/PerControllerConfigActivator.cs
+++ b/src/Climax.Web.Http/Services/PerControllerConfigActivator.cs
@@ -10,10 +10,23 @@ namespace Climax.Web.Http.Services
 {
     public class PerControllerConfigActivator : IHttpControllerActivator
     {
-        private static readonly DefaultHttpControllerActivator Default = new DefaultHttpControllerActivator();
+        private readonly IHttpControllerActivator _innerActivator;
 
         private readonly ConcurrentDictionary<Type, HttpConfiguration> _cache =
             new ConcurrentDictionary<Type, HttpConfiguration>();
+
+        public PerControllerConfigActivator() : this(new DefaultHttpControllerActivator())
+        {}
+
+        public PerControllerConfigActivator(IHttpControllerActivator innerActivator)
+        {
+            if (innerActivator == null)
+            {
+                throw new ArgumentNullException("innerActivator");
+            }
+
+            _innerActivator = innerActivator;
+        }
 
         public IHttpController Create(HttpRequestMessage request, HttpControllerDescriptor controllerDescriptor,
             Type controllerType)
@@ -34,7 +47,7 @@ namespace Climax.Web.Http.Services
                 }
             }
 
-            var result = Default.Create(request, controllerDescriptor, controllerType);
+            var result = _innerActivator.Create(request, controllerDescriptor, controllerType);
             return result;
         }
     }


### PR DESCRIPTION
This allows us to use a custom activator in conjunction with `PerControllerConfigActivator` instead of the previously hardcoded default one