### PR TITLE
Added extra features to 1.1.0 release

### DIFF
--- a/Climax.Web.Http.sln
+++ b/Climax.Web.Http.sln
@@ -12,6 +12,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{6E90F0
 		.nuget\NuGet.targets = .nuget\NuGet.targets
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Climax.Web.Http.Tests", "test\Climax.Web.Http.Tests\Climax.Web.Http.Tests.csproj", "{99C1EBF9-8CAC-42A5-9C5A-8F865F42C736}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -22,6 +24,10 @@ Global
 		{7ED19D2D-FD99-48A2-82A4-538E1C8DBD00}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7ED19D2D-FD99-48A2-82A4-538E1C8DBD00}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7ED19D2D-FD99-48A2-82A4-538E1C8DBD00}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99C1EBF9-8CAC-42A5-9C5A-8F865F42C736}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99C1EBF9-8CAC-42A5-9C5A-8F865F42C736}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99C1EBF9-8CAC-42A5-9C5A-8F865F42C736}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99C1EBF9-8CAC-42A5-9C5A-8F865F42C736}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,9 @@
 ### 1.1.0
 * Added support for a nested activator in `PerControllerConfigActivator`
 * Added `StringCollectionConstraint` and `EnumConstraint` which can be used as custom route constraints.
+* Added `CentralizedPrefixProvider` which allows the devloper to set a global `RoutePrefix`
+* Added `SimpleArrayModelBinder<T>` which makes it easy to bind delimited arrays from URI
+* Deprecated `StringArrayModelBinder` - in favor of the new `SimpleArrayModelBinder<T>`
 
 ### 1.0 - 23 March 2015
 * First release.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 ### 1.1.0
 * Added support for a nested activator in `PerControllerConfigActivator`
+* Added `StringCollectionConstraint` and `EnumConstraint` which can be used as custom route constraints.
 
 ### 1.0 - 23 March 2015
 * First release.

--- a/src/Climax.Web.Http/Binders/SimpleArrayModelBinder.cs
+++ b/src/Climax.Web.Http/Binders/SimpleArrayModelBinder.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Linq;
+using System.Web.Http.Controllers;
+using System.Web.Http.ModelBinding;
+
+namespace Climax.Web.Http.Binders
+{
+    public class SimpleArrayModelBinder<T> : IModelBinder
+    {
+        private readonly string _separator;
+
+        public SimpleArrayModelBinder()
+            : this(";")
+        {
+        }
+
+        public SimpleArrayModelBinder(string separator)
+        {
+            _separator = separator;
+        }
+
+        public bool BindModel(HttpActionContext actionContext, ModelBindingContext bindingContext)
+        {
+            var key = bindingContext.ModelName;
+            var val = bindingContext.ValueProvider.GetValue(key);
+            try
+            {
+                if (val != null)
+                {
+                    var s = val.AttemptedValue;
+                    if (s != null && s.IndexOf(_separator, StringComparison.Ordinal) > 0)
+                    {
+                        var stringArray = s.Split(new[] { _separator }, StringSplitOptions.None);
+                        bindingContext.Model = stringArray.Select(x => (T)Convert.ChangeType(x, typeof(T))).ToArray();
+                    }
+                    else
+                    {
+                        bindingContext.Model = new[] { (T)Convert.ChangeType(s, typeof(T)) };
+                    }
+
+                    return true;
+                }
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Climax.Web.Http/Binders/SimpleArrayModelBinderProvider.cs
+++ b/src/Climax.Web.Http/Binders/SimpleArrayModelBinderProvider.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Web.Http;
+using System.Web.Http.ModelBinding;
+
+namespace Climax.Web.Http.Binders
+{
+    public class SimpleArrayModelBinderProvider : ModelBinderProvider
+    {
+        public override IModelBinder GetBinder(HttpConfiguration configuration, Type modelType)
+        {
+            if (modelType == null)
+            {
+                throw new ArgumentNullException();
+            }
+
+            if (!modelType.IsArray)
+            {
+                return null;
+            }
+
+            var elementType = modelType.GetElementType();
+            if (elementType.IsPrimitive || typeof(string) == elementType)
+            {
+                return (IModelBinder)Activator.CreateInstance(typeof(SimpleArrayModelBinder<>).MakeGenericType(elementType));
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Climax.Web.Http/Binders/StringArrayModelBinder.cs
+++ b/src/Climax.Web.Http/Binders/StringArrayModelBinder.cs
@@ -4,6 +4,7 @@ using System.Web.Http.ModelBinding;
 
 namespace Climax.Web.Http.Binders
 {
+    [Obsolete("Please use SimpleArrayModelBinder instead.")]
     public class StringArrayModelBinder : IModelBinder
     {
         public bool BindModel(HttpActionContext actionContext, ModelBindingContext bindingContext)

--- a/src/Climax.Web.Http/Climax.Web.Http.csproj
+++ b/src/Climax.Web.Http/Climax.Web.Http.csproj
@@ -54,6 +54,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Binders\SimpleArrayModelBinder.cs" />
+    <Compile Include="Binders\SimpleArrayModelBinderProvider.cs" />
     <Compile Include="Binders\StringArrayModelBinder.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Constraints\EnumConstraint.cs" />
@@ -72,6 +74,7 @@
     <Compile Include="MediaTypes.cs" />
     <Compile Include="Results\FileWithDispositionHttpActionResult.cs" />
     <Compile Include="Results\PlainTextResult.cs" />
+    <Compile Include="Services\CentralizedPrefixProvider.cs" />
     <Compile Include="Services\NonControllerHttpControllerTypeResolver.cs" />
     <Compile Include="Services\InjectAttribute.cs" />
     <Compile Include="Services\InjectParameterBinding.cs" />

--- a/src/Climax.Web.Http/Constraints/EnumConstraint.cs
+++ b/src/Climax.Web.Http/Constraints/EnumConstraint.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Web.Http.Routing;
+
+namespace Climax.Web.Http.Constraints
+{
+    public class EnumConstraint : IHttpRouteConstraint
+    {
+        private static readonly ConcurrentDictionary<string, string[]> EnumDefinitions = new ConcurrentDictionary<string, string[]>();
+
+        public EnumConstraint(string enumName)
+        {
+            EnumName = enumName;
+        }
+
+        public string EnumName { get; private set; }
+
+        public bool Match(HttpRequestMessage request, IHttpRoute route, string parameterName, IDictionary<string, object> values,
+            HttpRouteDirection routeDirection)
+        {
+            object value;
+            if (values.TryGetValue(parameterName, out value) && value != null)
+            {
+                string[] validValues;
+                if (!EnumDefinitions.TryGetValue(EnumName, out validValues))
+                {
+                    var type = Type.GetType(EnumName);
+                    validValues = type != null ? Enum.GetNames(type) : new string[0];
+                    EnumDefinitions.TryAdd(EnumName, validValues);
+                }
+
+                return validValues.Contains(value.ToString(), StringComparer.OrdinalIgnoreCase);
+            }
+            return false;
+        }
+    }
+}

--- a/src/Climax.Web.Http/Constraints/StringCollectionConstraint.cs
+++ b/src/Climax.Web.Http/Constraints/StringCollectionConstraint.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Web.Http.Routing;
+
+namespace Climax.Web.Http.Constraints
+{
+    public class StringCollectionConstraint : IHttpRouteConstraint
+    {
+        public StringCollectionConstraint(string values)
+        {
+            if (values == null)
+            {
+                throw new ArgumentNullException("values");
+            }
+
+            Values = values.Split(',');
+        }
+
+        protected StringCollectionConstraint(string[] values)
+        {
+            if (values == null)
+            {
+                throw new ArgumentNullException("values");
+            }
+
+            Values = values;
+        }
+
+        public IEnumerable<string> Values { get; private set; }
+
+        public bool Match(HttpRequestMessage request, IHttpRoute route, string parameterName,
+            IDictionary<string, object> values, HttpRouteDirection routeDirection)
+        {
+            object value;
+            if (values.TryGetValue(parameterName, out value) && value != null)
+            {
+                return Values.Contains(value.ToString(), StringComparer.OrdinalIgnoreCase);
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Climax.Web.Http/Services/CentralizedPrefixProvider.cs
+++ b/src/Climax.Web.Http/Services/CentralizedPrefixProvider.cs
@@ -1,0 +1,21 @@
+﻿using System.Web.Http.Controllers;
+using System.Web.Http.Routing;
+
+namespace Climax.Web.Http.Services
+{
+    public class CentralizedPrefixProvider : DefaultDirectRouteProvider
+    {
+        private readonly string _centralizedPrefix;
+
+        public CentralizedPrefixProvider(string centralizedPrefix)
+        {
+            _centralizedPrefix = centralizedPrefix;
+        }
+
+        protected override string GetRoutePrefix(HttpControllerDescriptor controllerDescriptor)
+        {
+            var existingPrefix = base.GetRoutePrefix(controllerDescriptor);
+            return existingPrefix ?? _centralizedPrefix;
+        }
+    }
+}

--- a/test/Climax.Web.Http.Tests/Climax.Web.Http.Tests.csproj
+++ b/test/Climax.Web.Http.Tests/Climax.Web.Http.Tests.csproj
@@ -63,6 +63,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SimpleArrayModelBinderProviderTests.cs" />
+    <Compile Include="SimpleArrayModelBinderTests.cs" />
     <Compile Include="StringCollectionConstraintTests.cs" />
     <Compile Include="EnumConstraintTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/test/Climax.Web.Http.Tests/Climax.Web.Http.Tests.csproj
+++ b/test/Climax.Web.Http.Tests/Climax.Web.Http.Tests.csproj
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{7ED19D2D-FD99-48A2-82A4-538E1C8DBD00}</ProjectGuid>
+    <ProjectGuid>{99C1EBF9-8CAC-42A5-9C5A-8F865F42C736}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Climax.Web.Http</RootNamespace>
-    <AssemblyName>Climax.Web.Http</AssemblyName>
+    <RootNamespace>Climax.Web.Http.Tests</RootNamespace>
+    <AssemblyName>Climax.Web.Http.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -32,9 +32,18 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Moq">
+      <HintPath>..\..\packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Should">
+      <HintPath>..\..\packages\Should.1.1.20\lib\Should.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -54,38 +63,17 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Binders\StringArrayModelBinder.cs" />
-    <Compile Include="Constants.cs" />
-    <Compile Include="Constraints\EnumConstraint.cs" />
-    <Compile Include="Constraints\StringCollectionConstraint.cs" />
-    <Compile Include="DispositionType.cs" />
-    <Compile Include="Extensions\HttpConfigurationExtensions.cs" />
-    <Compile Include="Extensions\HttpRequestMessageExtensions.cs" />
-    <Compile Include="Extensions\StringExtensions.cs" />
-    <Compile Include="FallbackHeaderConstants.cs" />
-    <Compile Include="Filters\CheckModelStateAttribute.cs" />
-    <Compile Include="Filters\ModelNullCheckType.cs" />
-    <Compile Include="Handlers\HeadMessageHandler.cs" />
-    <Compile Include="Handlers\ThreadCultureMessageHandler.cs" />
+    <Compile Include="StringCollectionConstraintTests.cs" />
+    <Compile Include="EnumConstraintTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Results\FileHttpActionResult.cs" />
-    <Compile Include="MediaTypes.cs" />
-    <Compile Include="Results\FileWithDispositionHttpActionResult.cs" />
-    <Compile Include="Results\PlainTextResult.cs" />
-    <Compile Include="Services\NonControllerHttpControllerTypeResolver.cs" />
-    <Compile Include="Services\InjectAttribute.cs" />
-    <Compile Include="Services\InjectParameterBinding.cs" />
-    <Compile Include="Services\JsonContentNegotiator.cs" />
-    <Compile Include="Services\RouteDataValuesOnlyAttribute.cs" />
-    <Compile Include="Services\PerControllerConfigActivator.cs" />
-    <Compile Include="Services\SmartHttpActionInvoker.cs" />
-    <Compile Include="Services\Versioning\IVersionParser.cs" />
-    <Compile Include="Services\Versioning\VersionedRouteAttribute.cs" />
-    <Compile Include="Services\Versioning\VersionConstraint.cs" />
-    <Compile Include="Services\Versioning\VersionParser.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <ProjectReference Include="..\..\src\Climax.Web.Http\Climax.Web.Http.csproj">
+      <Project>{7ed19d2d-fd99-48a2-82a4-538e1c8dbd00}</Project>
+      <Name>Climax.Web.Http</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/test/Climax.Web.Http.Tests/EnumConstraintTests.cs
+++ b/test/Climax.Web.Http.Tests/EnumConstraintTests.cs
@@ -7,13 +7,18 @@ using Should;
 
 namespace Climax.Web.Http.Tests
 {
+    public enum TestEnum
+    {
+        Foo
+    }
+
     [TestFixture]
     public class EnumConstraintTests
     {
         [Test]
         public void ShouldMatch_IfParameterValue_InTheEnumMembers([Values("foo", "notfoo")] string input)
         {
-            var constraint = new EnumConstraint("Honda.Models.Web.Tests.TestEnum, Honda.Models.Web.Tests");
+            var constraint = new EnumConstraint("Climax.Web.Http.Tests.TestEnum, Climax.Web.Http.Tests");
 
             var result = constraint.Match(new HttpRequestMessage(), new Mock<IHttpRoute>().Object, "test",
                 new HttpRouteValueDictionary

--- a/test/Climax.Web.Http.Tests/EnumConstraintTests.cs
+++ b/test/Climax.Web.Http.Tests/EnumConstraintTests.cs
@@ -1,0 +1,34 @@
+﻿using System.Net.Http;
+using System.Web.Http.Routing;
+using Climax.Web.Http.Constraints;
+using Moq;
+using NUnit.Framework;
+using Should;
+
+namespace Climax.Web.Http.Tests
+{
+    [TestFixture]
+    public class EnumConstraintTests
+    {
+        [Test]
+        public void ShouldMatch_IfParameterValue_InTheEnumMembers([Values("foo", "notfoo")] string input)
+        {
+            var constraint = new EnumConstraint("Honda.Models.Web.Tests.TestEnum, Honda.Models.Web.Tests");
+
+            var result = constraint.Match(new HttpRequestMessage(), new Mock<IHttpRoute>().Object, "test",
+                new HttpRouteValueDictionary
+                {
+                    {"test", input}
+                }, HttpRouteDirection.UriResolution);
+
+            if (input == "foo")
+            {
+                result.ShouldBeTrue();
+            }
+            else
+            {
+                result.ShouldBeFalse();
+            }
+        }
+    }
+}

--- a/test/Climax.Web.Http.Tests/Properties/AssemblyInfo.cs
+++ b/test/Climax.Web.Http.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Climax.Web.Http.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Climax.Web.Http.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a29bad63-5689-49ee-8d1b-de59b52d48d2")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/Climax.Web.Http.Tests/SimpleArrayModelBinderProviderTests.cs
+++ b/test/Climax.Web.Http.Tests/SimpleArrayModelBinderProviderTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Web.Http;
+using Climax.Web.Http.Binders;
+using NUnit.Framework;
+using Should;
+
+namespace Climax.Web.Http.Tests
+{
+    [TestFixture]
+    public class SimpleArrayModelBinderProviderTests
+    {
+        [Test]
+        public void GetBinder_ShouldThrow_IfTypeIsNull()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new SimpleArrayModelBinderProvider().GetBinder(new HttpConfiguration(), null));
+        }
+
+        [Test]
+        public void GetBinder_ReturnsNull_ForNonArrays()
+        {
+            var provider = new SimpleArrayModelBinderProvider();
+            provider.GetBinder(new HttpConfiguration(), typeof(int)).ShouldBeNull();
+        }
+
+        [Test]
+        public void GetBinder_ReturnsNull_ForNonPrimitives()
+        {
+            var provider = new SimpleArrayModelBinderProvider();
+            provider.GetBinder(new HttpConfiguration(), typeof(HttpConfiguration)).ShouldBeNull();
+        }
+
+        [Test]
+        public void GetBinder_ReturnssimpleArrayModelBinder_ForPrimitiveArrys()
+        {
+            var provider = new SimpleArrayModelBinderProvider();
+            provider.GetBinder(new HttpConfiguration(), typeof(int[])).ShouldBeType(typeof(SimpleArrayModelBinder<int>));
+            provider.GetBinder(new HttpConfiguration(), typeof(string[])).ShouldBeType(typeof(SimpleArrayModelBinder<string>));
+            provider.GetBinder(new HttpConfiguration(), typeof(double[])).ShouldBeType(typeof(SimpleArrayModelBinder<double>));
+        }
+    }
+}

--- a/test/Climax.Web.Http.Tests/SimpleArrayModelBinderTests.cs
+++ b/test/Climax.Web.Http.Tests/SimpleArrayModelBinderTests.cs
@@ -1,0 +1,44 @@
+﻿using System.Globalization;
+using System.Linq;
+using System.Web.Http.Controllers;
+using System.Web.Http.Metadata;
+using System.Web.Http.Metadata.Providers;
+using System.Web.Http.ModelBinding;
+using System.Web.Http.ValueProviders;
+using Climax.Web.Http.Binders;
+using Moq;
+using NUnit.Framework;
+using Should;
+
+namespace Climax.Web.Http.Tests
+{
+    [TestFixture]
+    public class SimpleArrayModelBinderTests
+    {
+        [Test]
+        public void BindModel_CanBindIntArray([Values(";", ",", "-")] string separator)
+        {
+            var val = string.Join(separator, new[] { 1, 2, 3 });
+            var valueProvider = new Mock<IValueProvider>();
+            valueProvider.Setup(x => x.GetValue("foo"))
+                .Returns(new ValueProviderResult(val, val, CultureInfo.CurrentCulture));
+
+            var ctx = new ModelBindingContext
+            {
+                ModelMetadata = new ModelMetadata(new EmptyModelMetadataProvider(), null, null, typeof(int[]), null),
+                ModelName = "foo",
+                ValueProvider = valueProvider.Object
+            };
+
+            var binder = separator == ";"
+                ? new SimpleArrayModelBinder<int>()
+                : new SimpleArrayModelBinder<int>(separator);
+            var result = binder.BindModel(new HttpActionContext(), ctx);
+
+            ctx.Model.ShouldBeType<int[]>();
+            ((int[])ctx.Model).Count().ShouldEqual(3);
+            ((int[])ctx.Model).First().ShouldEqual(1);
+            ((int[])ctx.Model).Last().ShouldEqual(3);
+        }
+    }
+}

--- a/test/Climax.Web.Http.Tests/StringCollectionConstraintTests.cs
+++ b/test/Climax.Web.Http.Tests/StringCollectionConstraintTests.cs
@@ -1,0 +1,34 @@
+﻿using System.Net.Http;
+using System.Web.Http.Routing;
+using Climax.Web.Http.Constraints;
+using Moq;
+using NUnit.Framework;
+using Should;
+
+namespace Climax.Web.Http.Tests
+{
+    [TestFixture]
+    public class StringCollectionConstraintTests
+    {
+        [Test]
+        public void ShouldMatch_IfParameterValue_InTheList([Values("foo", "notfoo")] string input)
+        {
+            var constraint = new StringCollectionConstraint("foo,bar");
+
+            var result = constraint.Match(new HttpRequestMessage(), new Mock<IHttpRoute>().Object, "test",
+                new HttpRouteValueDictionary
+                {
+                    {"test", input}
+                }, HttpRouteDirection.UriResolution);
+
+            if (input == "foo")
+            {
+                result.ShouldBeTrue();
+            }
+            else
+            {
+                result.ShouldBeFalse();
+            }
+        }
+    }
+}

--- a/test/Climax.Web.Http.Tests/packages.config
+++ b/test/Climax.Web.Http.Tests/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
+  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="Should" version="1.1.20" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
* Added `StringCollectionConstraint` and `EnumConstraint` which can be used as custom route constraints.
* Added `CentralizedPrefixProvider` which allows the devloper to set a global `RoutePrefix`
* Added `SimpleArrayModelBinder<T>` which makes it easy to bind delimited arrays from URI
* Deprecated `StringArrayModelBinder` - in favor of the new `SimpleArrayModelBinder<T>`