### PR TITLE
Added IP filtering feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,45 @@ build.cmd
   config.ConfigureVersioning(new MyVersionParser());
   ```
 
+### IP filtering
+
+  Allows you to whitelist/black list your entire application using IP configuration settings from your `web.config` or `app.config` file. Available as a message handler (`IpFilterHandler`), an authorization filter (`IpFilterAttribute`) and a request extension on `HttpRequestMessage`.
+  
+  ```csharp
+  //handler
+  config.MessageHandlers.Add(new IpFilterHandler());
+  
+  //filter
+  [IpFilter]
+  public HttpResponseMessage Get()
+  {
+    //omitted for brevity
+  }
+  
+  //extension
+  public HttpResponseMessage Get()
+  {
+    if (Request.IsIpAllowed()) 
+    {
+      //do stuff
+    }
+  }
+  ```
+  
+  Configuration is done via `app.config`/`web.config`:
+  
+  ```xml
+  <configSections>
+    <section name="ipFiltering" type="Climax.Web.Http.Configuration.IpFilteringSection, Climax.Web.Http" />
+  </configSections>
+  <ipFiltering>
+    <ipAddresses>
+      <add address="192.168.0.196" /> <!-- this IP is explicitly allowed -->
+      <add address="192.168.0.197" denied="true" /> <!-- this IP is explicitly denied -->
+    </ipAddresses>
+  </ipFiltering>
+  ```
+
 ### Action Results
 
  - `FileHttpActionResult` - return a file as `StreamContent`

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 1.3.0
+* Added IP filtering support - as `HttpRequestMessage` extension methods, as an authorization filter (`IpFilterAttribute`) and as a message handler (`IpFilterHandler`). Configured in the `web.config`/`app.config`.
+
 ### 1.2.0
 * Added robust CORS configuration helpers
 

--- a/src/Climax.Web.Http/Climax.Web.Http.csproj
+++ b/src/Climax.Web.Http/Climax.Web.Http.csproj
@@ -64,6 +64,9 @@
     <Compile Include="Binders\SimpleArrayModelBinder.cs" />
     <Compile Include="Binders\SimpleArrayModelBinderProvider.cs" />
     <Compile Include="Binders\StringArrayModelBinder.cs" />
+    <Compile Include="Configuration\IpAddressElement.cs" />
+    <Compile Include="Configuration\IpAddressElementCollection.cs" />
+    <Compile Include="Configuration\IpFilteringSection.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Constraints\EnumConstraint.cs" />
     <Compile Include="Constraints\StringCollectionConstraint.cs" />
@@ -79,6 +82,8 @@
     <Compile Include="Filters\CheckModelStateAttribute.cs" />
     <Compile Include="Filters\ModelNullCheckType.cs" />
     <Compile Include="Handlers\HeadMessageHandler.cs" />
+    <Compile Include="Filters\IpFilterAttribute.cs" />
+    <Compile Include="Handlers\IpFilterHandler.cs" />
     <Compile Include="Handlers\ThreadCultureMessageHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Results\FileHttpActionResult.cs" />

--- a/src/Climax.Web.Http/Configuration/IpAddressElement.cs
+++ b/src/Climax.Web.Http/Configuration/IpAddressElement.cs
@@ -1,0 +1,21 @@
+using System.Configuration;
+
+namespace Climax.Web.Http.Configuration
+{
+    public class IpAddressElement : ConfigurationElement
+    {
+        [ConfigurationProperty("address", IsKey = true, IsRequired = true)]
+        public string Address
+        {
+            get { return (string)this["address"]; }
+            set { this["address"] = value; }
+        }
+
+        [ConfigurationProperty("denied", IsRequired = false)]
+        public bool Denied
+        {
+            get { return (bool)this["denied"]; }
+            set { this["denied"] = value; }
+        }
+    }
+}

--- a/src/Climax.Web.Http/Configuration/IpAddressElementCollection.cs
+++ b/src/Climax.Web.Http/Configuration/IpAddressElementCollection.cs
@@ -1,0 +1,18 @@
+using System.Configuration;
+
+namespace Climax.Web.Http.Configuration
+{
+    [ConfigurationCollection(typeof(IpAddressElement))]
+    public class IpAddressElementCollection : ConfigurationElementCollection
+    {
+        protected override ConfigurationElement CreateNewElement()
+        {
+            return new IpAddressElement();
+        }
+
+        protected override object GetElementKey(ConfigurationElement element)
+        {
+            return ((IpAddressElement)element).Address;
+        }
+    }
+}

--- a/src/Climax.Web.Http/Configuration/IpFilteringSection.cs
+++ b/src/Climax.Web.Http/Configuration/IpFilteringSection.cs
@@ -1,0 +1,14 @@
+using System.Configuration;
+
+namespace Climax.Web.Http.Configuration
+{
+    public class IpFilteringSection : ConfigurationSection
+    {
+        [ConfigurationProperty("ipAddresses", IsDefaultCollection = true)]
+        public IpAddressElementCollection IpAddresses
+        {
+            get { return (IpAddressElementCollection)this["ipAddresses"]; }
+            set { this["ipAddresses"] = value; }
+        }
+    }
+}

--- a/src/Climax.Web.Http/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/Climax.Web.Http/Extensions/HttpRequestMessageExtensions.cs
@@ -1,7 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
+using Climax.Web.Http.Configuration;
 
 namespace Climax.Web.Http.Extensions
 {
@@ -88,6 +91,54 @@ namespace Climax.Web.Http.Extensions
             }
 
             return default(T);
+        }
+
+        public static string GetHeader(this HttpRequestMessage request, string key)
+        {
+            IEnumerable<string> keys = null;
+            if (!request.Headers.TryGetValues(key, out keys))
+                return null;
+
+            return keys.First();
+        }
+
+        public static string[] GetXForwardedFor(this HttpRequestMessage request)
+        {
+            var xForwardedFor = request.GetHeader("X-Forwarded-For");
+            if (xForwardedFor == null) return new string[0];
+
+            var addresses = xForwardedFor.Split(',');
+
+            return addresses.Select(x =>
+            {
+                if (x.Contains(':'))
+                    return x.Split(':')[0];
+
+                return x;
+            }).ToArray();
+        }
+
+        public static bool IsIpAllowed(this HttpRequestMessage request)
+        {
+            var ipAddress = request.GetClientIpAddress();
+            var xForwardedFor = request.GetXForwardedFor();
+
+            if (!request.IsLocal())
+            {
+                var ipFiltering = ConfigurationManager.GetSection("ipFiltering") as IpFilteringSection;
+                if (ipFiltering != null)
+                {
+                    if (ipFiltering.IpAddresses.Cast<IpAddressElement>().Any(ip =>
+                        (ipAddress == ip.Address && !ip.Denied) ||
+                        (xForwardedFor.Contains(ip.Address) && !ip.Denied)))
+                    {
+                        return true;
+                    }
+
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/Climax.Web.Http/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/Climax.Web.Http/Extensions/HttpRequestMessageExtensions.cs
@@ -120,25 +120,23 @@ namespace Climax.Web.Http.Extensions
 
         public static bool IsIpAllowed(this HttpRequestMessage request)
         {
-            var ipAddress = request.GetClientIpAddress();
-            var xForwardedFor = request.GetXForwardedFor();
-
             if (!request.IsLocal())
             {
+                var ipAddress = request.GetClientIpAddress();
+
                 var ipFiltering = ConfigurationManager.GetSection("ipFiltering") as IpFilteringSection;
-                if (ipFiltering != null)
+                if (ipFiltering != null && ipFiltering.IpAddresses != null && ipFiltering.IpAddresses.Count > 0)
                 {
-                    if (ipFiltering.IpAddresses.Cast<IpAddressElement>().Any(ip =>
-                        (ipAddress == ip.Address && !ip.Denied) ||
-                        (xForwardedFor.Contains(ip.Address) && !ip.Denied)))
+                    if (ipFiltering.IpAddresses.Cast<IpAddressElement>().Any(ip => (ipAddress == ip.Address && !ip.Denied)))
                     {
                         return true;
                     }
 
+                    return false;
                 }
             }
 
-            return false;
+            return true;
         }
     }
 }

--- a/src/Climax.Web.Http/Filters/IpFilterAttribute.cs
+++ b/src/Climax.Web.Http/Filters/IpFilterAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System.Web.Http;
+using System.Web.Http.Controllers;
+using Climax.Web.Http.Extensions;
+
+namespace Climax.Web.Http.Filters
+{
+    public class IpFilterAttribute : AuthorizeAttribute
+    {
+        protected override bool IsAuthorized(HttpActionContext actionContext)
+        {
+            return actionContext.Request.IsIpAllowed();
+        }
+    }
+}

--- a/src/Climax.Web.Http/Handlers/IpFilterHandler.cs
+++ b/src/Climax.Web.Http/Handlers/IpFilterHandler.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Configuration;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Climax.Web.Http.Configuration;
+using Climax.Web.Http.Extensions;
+
+namespace Climax.Web.Http.Handlers
+{
+    public class IpFilterHandler : DelegatingHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            if (request.IsIpAllowed())
+            {
+                return await base.SendAsync(request, cancellationToken);
+            }
+
+            return request.CreateErrorResponse(HttpStatusCode.Forbidden, "Cannot view this resource");
+        }
+    }
+}

--- a/test/Climax.Web.Http.Tests/App.config
+++ b/test/Climax.Web.Http.Tests/App.config
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <configSections>
+    <section name="ipFiltering" type="Climax.Web.Http.Configuration.IpFilteringSection, Climax.Web.Http" />
+  </configSections>
+  <ipFiltering>
+    <ipAddresses>
+      <add address="192.168.0.196" />
+      <add address="192.168.0.197" denied="true" />
+    </ipAddresses>
+  </ipFiltering>
+</configuration>

--- a/test/Climax.Web.Http.Tests/Climax.Web.Http.Tests.csproj
+++ b/test/Climax.Web.Http.Tests/Climax.Web.Http.Tests.csproj
@@ -72,6 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Cors\ConfigurableCorsPolicyAttributeTests.cs" />
+    <Compile Include="HttpRequestMessageExtensionsTests.cs" />
     <Compile Include="SimpleArrayModelBinderProviderTests.cs" />
     <Compile Include="SimpleArrayModelBinderTests.cs" />
     <Compile Include="StringCollectionConstraintTests.cs" />
@@ -85,6 +86,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/test/Climax.Web.Http.Tests/HttpRequestMessageExtensionsTests.cs
+++ b/test/Climax.Web.Http.Tests/HttpRequestMessageExtensionsTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Climax.Web.Http.Extensions;
+using NUnit.Framework;
+using Should;
+
+namespace Climax.Web.Http.Tests
+{
+    public class IpConfig
+    {
+        public string Address { get; set; }
+    }
+
+    [TestFixture]
+    public class HttpRequestMessageExtensionsTests
+    {
+        [Test]
+        public void IsIpAllowed_ReturnsTrue_ForLocalIps()
+        {
+            var req = new HttpRequestMessage();
+            req.Properties.Add("MS_IsLocal", new Lazy<bool>(() => true));
+
+            req.IsIpAllowed().ShouldBeTrue();
+        }
+
+        [Test]
+        public void IsIpAllowed_ReturnsTrue_ForWhiteListedIps()
+        {
+            var req = new HttpRequestMessage();
+            req.Properties.Add("MS_IsLocal", new Lazy<bool>(() => false));
+            req.Properties.Add("System.ServiceModel.Channels.RemoteEndpointMessageProperty", new IpConfig { Address = "192.168.0.196" });
+
+            req.IsIpAllowed().ShouldBeTrue();
+        }
+
+        [Test]
+        public void IsIpAllowed_ReturnsTrue_ForNonWhiteListedIps()
+        {
+            var req = new HttpRequestMessage();
+            req.Properties.Add("MS_IsLocal", new Lazy<bool>(() => false));
+
+            req.IsIpAllowed().ShouldBeFalse();
+        }
+
+        [Test]
+        public void IsIpAllowed_ReturnsFalse_ForBlacklistedListedIps()
+        {
+            var req = new HttpRequestMessage();
+            req.Properties.Add("MS_IsLocal", new Lazy<bool>(() => false));
+            req.Properties.Add("System.ServiceModel.Channels.RemoteEndpointMessageProperty", new IpConfig { Address = "192.168.0.197" });
+
+            req.IsIpAllowed().ShouldBeFalse();
+        } 
+    }
+}


### PR DESCRIPTION
### IP filtering

  Allows you to whitelist/black list your entire application using IP configuration settings from your `web.config` or `app.config` file. Available as a message handler (`IpFilterHandler`), an authorization filter (`IpFilterAttribute`) and a request extension on `HttpRequestMessage`.
  
  ```csharp
  //handler
  config.MessageHandlers.Add(new IpFilterHandler());
  
  //filter
  [IpFilter]
  public HttpResponseMessage Get()
  {
    //omitted for brevity
  }
  
  //extension
  public HttpResponseMessage Get()
  {
    if (Request.IsIpAllowed()) 
    {
      //do stuff
    }
  }
  ```
  
  Configuration is done via `app.config`/`web.config`:
  
  ```xml
  <configSections>
    <section name="ipFiltering" type="Climax.Web.Http.Configuration.IpFilteringSection, Climax.Web.Http" />
  </configSections>
  <ipFiltering>
    <ipAddresses>
      <add address="192.168.0.196" /> <!-- this IP is explicitly allowed -->
      <add address="192.168.0.197" denied="true" /> <!-- this IP is explicitly denied -->
    </ipAddresses>
  </ipFiltering>
  ```