### PR TITLE
added trimming around header/origin/method parsing

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 1.3.2
+* Fixed a CORS bug - ensure each origin is trimmed after splitting the string entry from config file.
+
 ### 1.3.1
 * Mark `request.IsLocal()` extension method as obsolete, in favor of the native Web API `request.GetRequestContext().IsLocal` flag.
 * Ensure IP filtering works well with OWIN hosting.

--- a/src/Climax.Web.Http/Cors/ConfigurableCorsPolicyAttribute.cs
+++ b/src/Climax.Web.Http/Cors/ConfigurableCorsPolicyAttribute.cs
@@ -28,7 +28,7 @@ namespace Climax.Web.Http.Cors
                     }
                     else
                     {
-                        policy.Headers.Split(';').ToList().ForEach(x => _policy.Headers.Add(x));
+                        policy.Headers.Split(new[] { ";" }, StringSplitOptions.RemoveEmptyEntries).ToList().ForEach(x => _policy.Headers.Add(x.Trim()));
                     }
 
                     if (policy.Methods == "*")
@@ -37,7 +37,7 @@ namespace Climax.Web.Http.Cors
                     }
                     else
                     {
-                        policy.Methods.Split(';').ToList().ForEach(x => _policy.Methods.Add(x));
+                        policy.Methods.Split(new[] { ";" }, StringSplitOptions.RemoveEmptyEntries).ToList().ForEach(x => _policy.Methods.Add(x.Trim()));
                     }
 
                     if (policy.Origins == "*")
@@ -46,7 +46,7 @@ namespace Climax.Web.Http.Cors
                     }
                     else
                     {
-                        policy.Origins.Split(';').ToList().ForEach(x => _policy.Origins.Add(x));
+                        policy.Origins.Split(new [] {";"}, StringSplitOptions.RemoveEmptyEntries).ToList().ForEach(x => _policy.Origins.Add(x.Trim()));
                     }
                 }
             }

--- a/test/Climax.Web.Http.Tests/Cors/ConfigurableCorsPolicyAttributeTests.cs
+++ b/test/Climax.Web.Http.Tests/Cors/ConfigurableCorsPolicyAttributeTests.cs
@@ -69,5 +69,31 @@ namespace Climax.Web.Http.Tests.Cors
             policy.Origins.ShouldContain("http://foo.com");
             policy.Origins.ShouldContain("http://www.abc.com");
         }
+
+        [Test]
+        public void Ctor_TrimsUnnecessaryWhitespaceAroundOrigins()
+        {
+            var elements = new CorsElementCollection();
+            var fooElement = new CorsElement
+            {
+                Name = "foo",
+                Headers = "*",
+                Methods = "*",
+                Origins = "\r\n     http://foo.com;\r\n     http://www.abc.com"
+            };
+            elements.Add(fooElement);
+
+            var corsSection = new CorsSection
+            {
+                CorsPolicies = elements
+            };
+
+            var attr = new ConfigurableCorsPolicyAttribute("foo", corsSection);
+            var policy = attr.GetCorsPolicyAsync(new HttpRequestMessage(), default(CancellationToken)).Result;
+            
+            policy.Origins.Count.ShouldEqual(2);
+            policy.Origins[0].ShouldEqual("http://foo.com");
+            policy.Origins[1].ShouldEqual("http://www.abc.com");
+        }
     }
 }

--- a/test/Climax.Web.Http.Tests/Cors/ConfigurableCorsPolicyAttributeTests.cs
+++ b/test/Climax.Web.Http.Tests/Cors/ConfigurableCorsPolicyAttributeTests.cs
@@ -95,5 +95,57 @@ namespace Climax.Web.Http.Tests.Cors
             policy.Origins[0].ShouldEqual("http://foo.com");
             policy.Origins[1].ShouldEqual("http://www.abc.com");
         }
+
+        [Test]
+        public void Ctor_TrimsUnnecessaryWhitespaceAroundMethods()
+        {
+            var elements = new CorsElementCollection();
+            var fooElement = new CorsElement
+            {
+                Name = "foo",
+                Headers = "*",
+                Methods = "\r\n    GET;\r\n    POST",
+                Origins = "*"
+            };
+            elements.Add(fooElement);
+
+            var corsSection = new CorsSection
+            {
+                CorsPolicies = elements
+            };
+
+            var attr = new ConfigurableCorsPolicyAttribute("foo", corsSection);
+            var policy = attr.GetCorsPolicyAsync(new HttpRequestMessage(), default(CancellationToken)).Result;
+
+            policy.Methods.Count.ShouldEqual(2);
+            policy.Methods[0].ShouldEqual("GET");
+            policy.Methods[1].ShouldEqual("POST");
+        }
+
+        [Test]
+        public void Ctor_TrimsUnnecessaryWhitespaceAroundHeaders()
+        {
+            var elements = new CorsElementCollection();
+            var fooElement = new CorsElement
+            {
+                Name = "foo",
+                Headers = "\r\n    X-Api-Rate;\r\n    Foo",
+                Methods = "*",
+                Origins = "*"
+            };
+            elements.Add(fooElement);
+
+            var corsSection = new CorsSection
+            {
+                CorsPolicies = elements
+            };
+
+            var attr = new ConfigurableCorsPolicyAttribute("foo", corsSection);
+            var policy = attr.GetCorsPolicyAsync(new HttpRequestMessage(), default(CancellationToken)).Result;
+
+            policy.Headers.Count.ShouldEqual(2);
+            policy.Headers[0].ShouldEqual("X-Api-Rate");
+            policy.Headers[1].ShouldEqual("Foo");
+        }
     }
 }


### PR DESCRIPTION
Allows adding entries as new lines in web.config (instead of forcing everything to be on one line